### PR TITLE
Prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# [v0.1.0](https://github.com/dtan4/ct2stimer/releases/tag/v0.1.0) (2017-01-30)
+
+Initial release.

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 
 .PHONY: cross-build
 cross-build: generate
-	for os in darwin linux windows; do \
+	for os in linux; do \
 		for arch in amd64 386; do \
 			GOOS=$$os GOARCH=$$arch go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
 		done; \


### PR DESCRIPTION
systemd can run on Linux only, so we just build Linux binaries only.