### PR TITLE
Set username who executes process

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -26,6 +26,7 @@ var opts = struct {
 	nameRegexp string
 	outdir     string
 	reload     bool
+	user       string
 	version    bool
 }{}
 
@@ -39,6 +40,7 @@ func parseArgs(args []string) error {
 	f.StringVar(&opts.nameRegexp, "name-regexp", "", "regexp to extract scheduler name from crontab")
 	f.StringVarP(&opts.outdir, "outdir", "o", systemd.DefaultUnitsDirectory, "directory to save systemd files")
 	f.BoolVar(&opts.reload, "reload", false, "reload & start genreated timers")
+	f.StringVar(&opts.user, "user", "", "unix username who executes process")
 	f.BoolVarP(&opts.version, "version", "v", false, "print version")
 
 	f.Parse(args)
@@ -127,7 +129,7 @@ func run(args []string) int {
 			return exitCodeError
 		}
 
-		service, err := systemd.GenerateService(name, schedule.Command, opts.after)
+		service, err := systemd.GenerateService(name, schedule.Command, opts.after, opts.user)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return exitCodeError

--- a/systemd/templates/service.tmpl
+++ b/systemd/templates/service.tmpl
@@ -5,4 +5,5 @@ After={{ .After }}{{ end }}
 [Service]
 TimeoutStartSec=0
 ExecStart={{ .Command }}
-Type=oneshot
+Type=oneshot{{ if .User }}
+User={{ .User }}{{ end }}

--- a/systemd/unit.go
+++ b/systemd/unit.go
@@ -12,6 +12,7 @@ type ServiceData struct {
 	Name    string
 	Command string
 	After   string
+	User    string
 }
 
 // TimerData represents data set of systemd Timer
@@ -21,7 +22,7 @@ type TimerData struct {
 }
 
 // GenerateService generates new systemd Service
-func GenerateService(name, command, after string) (string, error) {
+func GenerateService(name, command, after, user string) (string, error) {
 	body, err := Asset("templates/service.tmpl")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load service template")
@@ -38,6 +39,7 @@ func GenerateService(name, command, after string) (string, error) {
 		Name:    name,
 		Command: command,
 		After:   after,
+		User:    user,
 	}); err != nil {
 		return "", errors.Wrap(err, "failed to dispatch values in service template")
 	}

--- a/systemd/unit_test.go
+++ b/systemd/unit_test.go
@@ -9,12 +9,14 @@ func TestGenerateService(t *testing.T) {
 		name     string
 		command  string
 		after    string
+		user     string
 		expected string
 	}{
 		{
 			name:    "ct2stimer",
 			command: "/bin/bash docker run --rm ubuntu:16.04 echo hello",
 			after:   "docker.service",
+			user:    "",
 			expected: `[Unit]
 Description=ct2stimer service unit
 After=docker.service
@@ -29,6 +31,7 @@ Type=oneshot
 			name:    "ct2stimer",
 			command: "/bin/bash docker run --rm ubuntu:16.04 echo hello",
 			after:   "",
+			user:    "core",
 			expected: `[Unit]
 Description=ct2stimer service unit
 
@@ -36,12 +39,13 @@ Description=ct2stimer service unit
 TimeoutStartSec=0
 ExecStart=/bin/bash docker run --rm ubuntu:16.04 echo hello
 Type=oneshot
+User=core
 `,
 		},
 	}
 
 	for _, tc := range testcases {
-		got, err := GenerateService(tc.name, tc.command, tc.after)
+		got, err := GenerateService(tc.name, tc.command, tc.after, tc.user)
 		if err != nil {
 			t.Errorf("Error should not be raised. error: %s", err)
 		}


### PR DESCRIPTION
## WHY

For example, root user cannot read configration in `/home/core/.docker/config.json`.

## WHAT

Make it enable to specify username who executes process