### PR TITLE
Fix bug parsing crontab lines with multiple whitespace

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/dtan4/ct2stimer/crontab"
-	"github.com/dtan4/ct2stimer/systemd"
+	"./crontab"
+	"./systemd"
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 )

--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -60,7 +60,7 @@ func Parse(crontab string) ([]*Schedule, error) {
 			continue
 		}
 
-		ss := strings.SplitN(line, " ", 6)
+		ss := regexp.MustCompile(`\s+`).Split(line, 6)
 		if len(ss) < 6 {
 			return []*Schedule{}, errors.Errorf("line %q is invalid format", line)
 		}

--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -123,7 +123,8 @@ func (s *Schedule) NameByRegexp(nameRegexp *regexp.Regexp) string {
 
 	match := nameRegexp.FindStringSubmatch(s.Command)
 	if len(match) >= 2 {
-		name = match[1]
+		re := regexp.MustCompile(`[^A-Za-z0-9_]+`)
+		name = re.ReplaceAllString(match[1], "-")
 	} else {
 		name = ""
 	}

--- a/util.go
+++ b/util.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dtan4/ct2stimer/crontab"
-	"github.com/dtan4/ct2stimer/systemd"
+	"./crontab"
+	"./systemd"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
It fails to parse crontab lines with multiple whitespaces.

```$ bin/ct2stimer -f test.crontab -o /tmp/
failed to parse schedule spec "0   7 *": expected exactly 5 fields, found 3: [0 7 *]

$ cat test.crontab
0   7 * * * /path/to/command```